### PR TITLE
[unitaryHACK] exit-issue discussion on qdesk_interactive.js [WIP]

### DIFF
--- a/qdesk_interactive.js
+++ b/qdesk_interactive.js
@@ -199,6 +199,7 @@ function SysinReader(callback, intro) {
   process.stdin.on('end', () => {
     //process.stdin.setRawMode(false);
     process.stdout.write('Good-bye\n');
+    process.exit(0);
   });
 }
 // function test() {


### PR DESCRIPTION
[unitaryHACK]
  I am truly amazed at this  :sparkles:quantum:sparkles: software.

  As I was trying it out, when I hit _CTRL-C CTRL-Z_ or _CTRL-D_ I thought it would stop and exit the program so I could swap to other projects however it did not and would just continue looking for input.

  To test I added an exit command into the **qdesk_interactive.js** code and found it did as I expected (see exit-issue branch). 
  However I am unsure if I am fixing a bug or changing a desirable feature.

  If qcss is already working  by design when we stop a process with _CTRL-C_, is there another way to exit the program I am unaware of?
  If not, may I create an exit command by perhaps adding a "quit" or "exit" command to the qcss command line?
  
  I would really appreciate any feedback at all. :pray:

  Just so you are aware this pull has a 2nd purpose.  It is allowing myself to become more familiar with git and the git pull process itself as I examine the other [unitaryHACK] issues and choose which of the remaining ones to pursue.

  Thanks for reading and hope to chat more in the future. :bow:
